### PR TITLE
Pty and serial examples

### DIFF
--- a/src/components/middleware/io/CMakeLists.txt
+++ b/src/components/middleware/io/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(can_example)
+add_subdirectory(pty_example)
 add_subdirectory(udp_example)
 add_subdirectory(tcp_example)
+add_subdirectory(serial_example)

--- a/src/components/middleware/io/pty_example/CMakeLists.txt
+++ b/src/components/middleware/io/pty_example/CMakeLists.txt
@@ -1,0 +1,17 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  config.proto)
+
+set (APP_NAME goby3_example_pty)
+
+add_executable( ${APP_NAME}
+  main.cpp
+  ${PROTO_SRCS} ${PROTO_HDRS})
+
+target_link_libraries( ${APP_NAME}
+  goby
+  goby_zeromq
+  goby3_example_messages)
+
+if(export_goby_interfaces)
+  generate_interfaces(${APP_NAME})
+endif()

--- a/src/components/middleware/io/pty_example/README.md
+++ b/src/components/middleware/io/pty_example/README.md
@@ -1,0 +1,20 @@
+# PTY Example
+
+`goby3_example_pty` opens a pseudoterminal (pty) and connects the "master" end to the publish/subscribe interface of PTYThreadLineBased. The slave end is at `/tmp/ttygoby3-example` by default, or at the path specified by `pty_config.port`.
+
+The usual use of the PTYThreadLineBased is to create "virtual serial ports" for emulation/simulation of serial based sensors  entirely in software.
+
+At a minimum to run this example:
+
+```
+gobyd
+goby3_example_pty -vvv
+```
+
+Then write data into `/tmp/ttygoby3-example`.
+
+To change the virtual serial port location, baud, or end-of-line delimiter use, for example:
+
+```
+goby3_example_pty -vvv --pty_config 'port: "/tmp/ttytest" end_of_line: "\r\n" baud: 9600'
+```

--- a/src/components/middleware/io/pty_example/config.proto
+++ b/src/components/middleware/io/pty_example/config.proto
@@ -1,0 +1,13 @@
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/zeromq/protobuf/interprocess_config.proto";
+import "goby/middleware/protobuf/pty_config.proto";
+
+message PTYExampleConfig
+{
+    // required parameters for ApplicationBase3 class
+    optional goby.middleware.protobuf.AppConfig app = 1;
+    // required parameters for connecting to 'gobyd'
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+
+    optional goby.middleware.protobuf.PTYConfig pty_config = 3;
+}

--- a/src/components/middleware/io/pty_example/main.cpp
+++ b/src/components/middleware/io/pty_example/main.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include "goby/middleware/marshalling/protobuf.h"
+
+#include "goby/middleware/io/line_based/pty.h"
+#include "goby/zeromq/application/multi_thread.h"
+
+#include "config.pb.h"
+#include "messages/groups.h"
+
+#include "goby/middleware/group.h"
+
+using goby::glog;
+
+constexpr goby::middleware::Group pty_in{"pty_in"};
+constexpr goby::middleware::Group pty_out{"pty_out"};
+
+using AppBase = goby::zeromq::MultiThreadApplication<PTYExampleConfig>;
+using ThreadBase = goby::middleware::SimpleThread<PTYExampleConfig>;
+
+class PTYDataHandleThread : public ThreadBase
+{
+  public:
+    PTYDataHandleThread(const PTYExampleConfig& cfg) : ThreadBase(cfg)
+    {
+        interthread().subscribe<pty_in>([this](const goby::middleware::protobuf::IOData& data) {
+            glog.is_verbose() && glog << data.DebugString() << std::endl;
+        });
+    }
+
+    ~PTYDataHandleThread() {}
+};
+
+class PTYExample : public AppBase
+{
+  public:
+    PTYExample() : AppBase()
+    {
+        using PTYThread = goby::middleware::io::PTYThreadLineBased<pty_in, pty_out>;
+
+        launch_thread<PTYThread>(cfg().pty_config());
+        launch_thread<PTYDataHandleThread>();
+    }
+};
+
+class PTYConfigurator : public goby::middleware::ProtobufConfigurator<PTYExampleConfig>
+{
+  public:
+    PTYConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<PTYExampleConfig>(argc, argv)
+    {
+        PTYExampleConfig& cfg = mutable_cfg();
+
+        auto* pty_config = cfg.mutable_pty_config();
+        if (!cfg.pty_config().has_port())
+            pty_config->set_port("/tmp/ttygoby3-example");
+    }
+};
+
+int main(int argc, char* argv[]) { return goby::run<PTYExample>(PTYConfigurator(argc, argv)); }

--- a/src/components/middleware/io/serial_example/CMakeLists.txt
+++ b/src/components/middleware/io/serial_example/CMakeLists.txt
@@ -1,0 +1,17 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  config.proto)
+
+set (APP_NAME goby3_example_serial)
+
+add_executable( ${APP_NAME}
+  main.cpp
+  ${PROTO_SRCS} ${PROTO_HDRS})
+
+target_link_libraries( ${APP_NAME}
+  goby
+  goby_zeromq
+  goby3_example_messages)
+
+if(export_goby_interfaces)
+  generate_interfaces(${APP_NAME})
+endif()

--- a/src/components/middleware/io/serial_example/README.md
+++ b/src/components/middleware/io/serial_example/README.md
@@ -1,0 +1,19 @@
+# PTY Example
+
+`goby3_example_serial` opens an existing serial port and connects it to the publish/subscribe interface of SerialThreadLineBased.
+
+At a minimum to run this example:
+
+```
+gobyd
+socat pty,link=/tmp/ttytest1,raw,echo=0 pty,link=/tmp/ttytest2,raw,echo=0
+goby3_example_serial --serial 'port: "/tmp/ttytest1" end_of_line: "\r\n" baud: 9600' -vvv
+```
+
+This creates a connected pair of pseudoterminals (virtual serial ports) using `socat` and connects `goby3_example_serial` to one of them (`/tmp/ttytest1`). Any data written to `/tmp/ttytest2` will show up as a SerialThreadLineBased publication. For example:
+
+```
+printf 'hello world\r\n' > /tmp/ttytest2
+```
+
+Alternatively, you can use a real serial device (e.g. a GPS) instead of `socat`.

--- a/src/components/middleware/io/serial_example/config.proto
+++ b/src/components/middleware/io/serial_example/config.proto
@@ -1,0 +1,13 @@
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/zeromq/protobuf/interprocess_config.proto";
+import "goby/middleware/protobuf/serial_config.proto";
+
+message SerialExampleConfig
+{
+    // required parameters for ApplicationBase3 class
+    optional goby.middleware.protobuf.AppConfig app = 1;
+    // required parameters for connecting to 'gobyd'
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+
+    required goby.middleware.protobuf.SerialConfig serial = 3;
+}

--- a/src/components/middleware/io/serial_example/main.cpp
+++ b/src/components/middleware/io/serial_example/main.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include "goby/middleware/marshalling/protobuf.h"
+
+#include "goby/middleware/io/line_based/serial.h"
+#include "goby/zeromq/application/multi_thread.h"
+
+#include "config.pb.h"
+#include "messages/groups.h"
+
+#include "goby/middleware/group.h"
+
+using goby::glog;
+
+constexpr goby::middleware::Group serial_in{"serial_in"};
+constexpr goby::middleware::Group serial_out{"serial_out"};
+
+using AppBase = goby::zeromq::MultiThreadApplication<SerialExampleConfig>;
+using ThreadBase = goby::middleware::SimpleThread<SerialExampleConfig>;
+
+class SerialDataHandleThread : public ThreadBase
+{
+  public:
+    SerialDataHandleThread(const SerialExampleConfig& cfg) : ThreadBase(cfg)
+    {
+        interthread().subscribe<serial_in>([this](const goby::middleware::protobuf::IOData& data) {
+            glog.is_verbose() && glog << data.DebugString() << std::endl;
+        });
+    }
+
+    ~SerialDataHandleThread() {}
+};
+
+class SerialExample : public AppBase
+{
+  public:
+    SerialExample() : AppBase()
+    {
+        using SerialThread = goby::middleware::io::SerialThreadLineBased<serial_in, serial_out>;
+
+        launch_thread<SerialThread>(cfg().serial());
+        launch_thread<SerialDataHandleThread>();
+    }
+};
+
+int main(int argc, char* argv[]) { return goby::run<SerialExample>(argc, argv); }

--- a/src/interthread/basic_publisher_subscriber/CMakeLists.txt
+++ b/src/interthread/basic_publisher_subscriber/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(goby3_example_basic_interthread
 
 target_link_libraries(goby3_example_basic_interthread
   goby
-  goby_zeromq
   goby3_example_messages)
 
 if(export_goby_interfaces)

--- a/src/interthread/basic_publisher_subscriber/config.proto
+++ b/src/interthread/basic_publisher_subscriber/config.proto
@@ -1,12 +1,9 @@
 import "goby/middleware/protobuf/app_config.proto";
-import "goby/zeromq/protobuf/interprocess_config.proto";
 
 message BasicMultithreadPubSubConfig
 {
     // required parameters for ApplicationBase3 class
     optional goby.middleware.protobuf.AppConfig app = 1;
-    // required parameters for connecting to 'gobyd'
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
 
     optional int32 my_value = 3;
 }

--- a/src/interthread/basic_publisher_subscriber/publisher.h
+++ b/src/interthread/basic_publisher_subscriber/publisher.h
@@ -1,9 +1,10 @@
 #ifndef MULTITHREAD_PUBLISHER_H
 #define MULTITHREAD_PUBLISHER_H
 
-#include "config.pb.h"
 #include "goby/middleware/marshalling/protobuf.h"
-#include "goby/zeromq/application/multi_thread.h"
+
+#include "config.pb.h"
+#include "goby/middleware/application/multi_thread.h"
 #include "messages/groups.h"
 #include "messages/nav.pb.h"
 

--- a/src/interthread/basic_publisher_subscriber/subscriber.h
+++ b/src/interthread/basic_publisher_subscriber/subscriber.h
@@ -1,7 +1,10 @@
 #ifndef MULTITHREAD_SUBSCRIBER_H
 #define MULTITHREAD_SUBSCRIBER_H
 
-#include "goby/zeromq/application/single_thread.h"
+
+#include "goby/middleware/marshalling/protobuf.h"
+
+#include "goby/middleware/application/multi_thread.h"
 
 #include "messages/groups.h"
 #include "messages/nav.pb.h"


### PR DESCRIPTION
- New examples for using SerialThreadLineBased and PTYThreadLineBased.
- Clean up dependencies for interthread examples (no need for ZeroMQ here).